### PR TITLE
Drop dependency to java package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,12 @@
                     <license>Apache License, Version 2.0</license>
                     <group>Application/Database</group>
                     <sourceEncoding>utf-8</sourceEncoding>
+                    <!-- let users decide how to install java -->
+                    <!--
                     <requires>
                         <require>java &gt;= 7</require>
                     </requires>
+                  -->
                     <mappings>
                         <mapping>
                             <directory>/opt</directory>


### PR DESCRIPTION
There is not a single provider for Java and not all users install Java via Yum repositories as suggested at the following link:
 https://github.com/elastic/logstash/issues/6275